### PR TITLE
composer install 時にエラーになる問題を解消

### DIFF
--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -180,7 +180,8 @@ RUN set -eux; \
 	cd /; \
 	docker-php-source delete; \
 	\
-# -
+# install php zip extention
+# (Run before "purge --auto-remove" because it requires PHPIZE_DEPS.)
 	pecl update-channels; \
 	pecl install zip; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies

--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -26,7 +26,8 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
-		re2c
+		re2c \
+		libzip4
 
 # persistent / runtime deps
 RUN set -eux; \
@@ -35,6 +36,8 @@ RUN set -eux; \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		git \
+		unzip \
 		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*
@@ -177,6 +180,9 @@ RUN set -eux; \
 	cd /; \
 	docker-php-source delete; \
 	\
+# -
+	pecl update-channels; \
+	pecl install zip; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
@@ -202,6 +208,7 @@ RUN set -ex \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable opcache \
+	&& docker-php-ext-enable zip \
     # install composer
     && { \
       curl -sS https://getcomposer.org/installer; \

--- a/fpm/7.0/Dockerfile
+++ b/fpm/7.0/Dockerfile
@@ -181,7 +181,7 @@ RUN set -eux; \
 	docker-php-source delete; \
 	\
 # install php zip extention
-# (Run before "purge --auto-remove" because it requires PHPIZE_DEPS.)
+# (Run before "purge --auto-remove" because requires PHPIZE_DEPS.)
 	pecl update-channels; \
 	pecl install zip; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
@@ -209,7 +209,7 @@ RUN set -ex \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable opcache \
-	&& docker-php-ext-enable zip \
+    && docker-php-ext-enable zip \
     # install composer
     && { \
       curl -sS https://getcomposer.org/installer; \


### PR DESCRIPTION
`composer install` 時の下記エラーを解消

```
    Failed to download aura/installer-default from dist: The zip extension and unzip command are both missing, skipping.
Your command-line PHP is using multiple ini files. Run `php --ini` to show them.
    Now trying to download from source
  - Installing aura/installer-default (1.0.0): Cloning 52f8de3670

                                                                                                                                         
  [RuntimeException]                                                                                                                     
  Failed to clone https://github.com/auraphp/installer-default.git, git was not found, check that it is installed and in your PATH env.  
                                                                                                                                         
  sh: 1: git: not found     
```